### PR TITLE
Replace "for" with "this is" in call init.

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -127,7 +127,7 @@
       <h3>Init Phase</h3>
       <ol>
         <li>
-          Sender: "&lt;receiver&gt; for &lt;sender&gt;" or <em>"Alice (for) Bob“</em>
+          Sender: "&lt;receiver&gt; this is &lt;sender&gt;" or <em>"Alice this is Bob“</em>
         </li>
         <li>
             Receiver: "&lt;receiver&gt; go ahead" or <em>"Here is Bob, go ahead"</em>


### PR DESCRIPTION
Use other call procedure words in call initialization as the word "for" causes some confusion. The term "this is" is more common anyways (e.g., see [[1]](https://www.roteskreuz.at/fileadmin/user_upload/PDF/Wer_wir_sind/AutRC-Procedure_for_Radio_Communication_130716.pdf), [[2]](https://www.wildtalk.com/knowledge-base/good-radio-procedure/), [[3]](https://tasmaritime.com.au/TMR/index.php/technical/using-radio/item/390-basic-radio-procedure) or [[4]](https://www.oit.uci.edu/wp-content/uploads/Radio_Operator.pdf)).